### PR TITLE
Added method to get currently centered item

### DIFF
--- a/sample/src/main/java/com/muller/snappingsample/SnappingRecyclerView.java
+++ b/sample/src/main/java/com/muller/snappingsample/SnappingRecyclerView.java
@@ -374,6 +374,13 @@ public class SnappingRecyclerView extends RecyclerView {
 
 		return computeHorizontalScrollOffset();
 	}
+	
+	/**
+	 * Returns the currently centered item aka the selected item
+	 */
+	public int getSelectedPosition() {
+        	return _selectedPosition;
+    	}
 
 	@Override
 	protected void onDetachedFromWindow() {


### PR DESCRIPTION
The method returns the currently centered item aka the selected item which can be used later to get the selected item